### PR TITLE
Remove :? array and similar from functions for PHP 7.0 compatibility.

### DIFF
--- a/classes/attempt.php
+++ b/classes/attempt.php
@@ -106,7 +106,7 @@ class attempt {
      * @param string $categoryidnumber idnumber of the category to use.
      * @return \stdClass if the category was OK. If not null and problem and problemdetails are set.
      */
-    private function find_category(string $categoryidnumber): ?\stdClass {
+    private function find_category(string $categoryidnumber) {
         $coursecontext = \context_course::instance(utils::get_relevant_courseid($this->embedlocation->context));
         $category = utils::get_category_by_idnumber($coursecontext, $categoryidnumber);
         if (!$category) {

--- a/classes/form/embed_options_form.php
+++ b/classes/form/embed_options_form.php
@@ -165,7 +165,7 @@ class embed_options_form extends \moodleform {
      *
      * @return int|null the $userlimit option.
      */
-    protected function get_user_retriction(): ?int {
+    protected function get_user_retriction() {
         global $USER;
 
         $context = $this->_customdata['context'];

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -130,7 +130,7 @@ class utils {
      * @param string $idnumber the idnumber to look for.
      * @return \stdClass|null row from the question_categories table, or false if none.
      */
-    public static function get_category_by_idnumber(\context $context, string $idnumber): ?\stdClass {
+    public static function get_category_by_idnumber(\context $context, string $idnumber) {
         global $DB;
 
         $category = $DB->get_record_select('question_categories',
@@ -149,7 +149,7 @@ class utils {
      * @param string $idnumber the idnumber to look for.
      * @return \stdClass|null row from the question table, or false if none.
      */
-    public static function get_question_by_idnumber(int $categoryid, string $idnumber): ?\stdClass {
+    public static function get_question_by_idnumber(int $categoryid, string $idnumber) {
         global $DB;
 
         $question = $DB->get_record_select('question',

--- a/filter.php
+++ b/filter.php
@@ -180,7 +180,7 @@ class filter_embedquestion extends moodle_text_filter {
      * @param array $parts the individual 'name=options' strings.
      * @return array|null the parsed options, or false if they were malformed.
      */
-    public static function parse_options(array $parts): ?array {
+    public static function parse_options(array $parts) {
         $params = [];
         foreach ($parts as $part) {
             if (strpos($part, '=') === false) {


### PR DESCRIPTION
Please have Travis run for Moodle 3.6 on PHP 7.0, too.

Thanks!