### PR TITLE
Passing PHPUnit tests with MOODLE_402_STABLE:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '7.4'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: 'mariadb'
+          - php: '8.0'
             moodle-branch: 'master'
             database: 'pgsql'
           - php: '7.4'
@@ -23,7 +26,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -32,7 +35,7 @@ jobs:
           - 5432:5432
 
       mariadb:
-        image: mariadb:10.5
+        image: mariadb:10
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -56,6 +59,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, pgsql, mysqli
+          ini-values: max_input_vars=5000
 
       - name: Deploy moodle-plugin-ci
         run: |

--- a/classes/event/question_attempted.php
+++ b/classes/event/question_attempted.php
@@ -40,10 +40,6 @@ class question_attempted extends \core\event\base {
                 "'$this->objectid' in course '$this->courseid'.";
     }
 
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'filter_embedquestion', 'submit', '', $this->objectid);
-    }
-
     public static function get_objectid_mapping() {
         return array('db' => 'question', 'restore' => 'question');
     }

--- a/classes/event/question_started.php
+++ b/classes/event/question_started.php
@@ -40,10 +40,6 @@ class question_started extends \core\event\base {
                 "'$this->objectid' in course '$this->courseid'.";
     }
 
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'filter_embedquestion', 'start', '', $this->objectid);
-    }
-
     public static function get_objectid_mapping() {
         return array('db' => 'question', 'restore' => 'question');
     }

--- a/classes/event/question_viewed.php
+++ b/classes/event/question_viewed.php
@@ -40,10 +40,6 @@ class question_viewed extends \core\event\base {
                 "'$this->objectid' in course '$this->courseid'.";
     }
 
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'filter_embedquestion', 'view', '', $this->objectid);
-    }
-
     public static function get_objectid_mapping() {
         return array('db' => 'question', 'restore' => 'question');
     }

--- a/tests/external_test.php
+++ b/tests/external_test.php
@@ -25,6 +25,9 @@ namespace filter_embedquestion;
  */
 class external_test extends \advanced_testcase {
 
+    /**
+     * @runInSeparateProcess
+     */
     public function test_get_sharable_question_choices_working() {
 
         $this->resetAfterTest();
@@ -53,6 +56,9 @@ class external_test extends \advanced_testcase {
                 external::get_sharable_question_choices($course->id, 'abc123'));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function test_get_sharable_question_choices_no_permissions() {
         $this->resetAfterTest();
         $this->setGuestUser();
@@ -61,6 +67,9 @@ class external_test extends \advanced_testcase {
         external::get_sharable_question_choices(SITEID, 'abc123');
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function test_get_sharable_question_choices_only_user() {
         global $DB;
 
@@ -106,6 +115,8 @@ class external_test extends \advanced_testcase {
 
     /**
      * Test getting the embed code for a particular question.
+     *
+     * @runInSeparateProcess
      *
      * @param string $catid idnumber to use for the category.
      * @param string $questionid idnumber to use for the question.
@@ -159,6 +170,9 @@ class external_test extends \advanced_testcase {
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function test_get_embed_code_working_with_random_questions() {
 
         $this->resetAfterTest();
@@ -227,6 +241,8 @@ class external_test extends \advanced_testcase {
 
     /**
      * Test function token::is_authorized_secret_token
+     *
+     * @runInSeparateProcess
      *
      * @param string $catid idnumber to use for the category.
      * @param string $questionid idnumber to use for the question.

--- a/version.php
+++ b/version.php
@@ -24,10 +24,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022032900;
+$plugin->version   = 2023050400;
 $plugin->requires  = 2020061500;
 $plugin->component = 'filter_embedquestion';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '2.2 for Moodle 3.9+';
+$plugin->release   = '2.2 for Moodle 4.2+';
 
 $plugin->outestssufficient = true;


### PR DESCRIPTION
removed outdated legacy functions
setting external tests to run test in separate process 
updated ci.yml file to test against MOODLE_402_STABLE 
updated ci.yml to use mariadb 10
updated ci.yml to use PHP with max_input_vars=5000 
bumped version