### PR TITLE
issue #45: fix failing unit tests

### DIFF
--- a/tests/attempt_test.php
+++ b/tests/attempt_test.php
@@ -294,7 +294,7 @@ final class attempt_test extends \advanced_testcase {
             'Question bank</a></div>' .
             '<div class="filter_embedquestion-fill-link">' .
             '<button type="submit" name="fillwithcorrect" value="1" class="btn btn-link">' .
-            '<i class="icon fa fa-check fa-fw iconsmall" aria-hidden="true"  ></i>' .
+            '<i class="icon fa fa-check fa-fw iconsmall" aria-hidden="true" ></i>' .
             '<span>Fill with correct</span></button></div></div>~';
         $this->assertMatchesRegularExpression($expectedregex, $html);
         // Create an authenticated user.


### PR DESCRIPTION
Fixes #45 

The test is relying on a core template.  As part of applying https://moodle.atlassian.net/browse/MDL-85040 an extra space was removed from the core icon template. 

This fix aligns the test to a new core code. 

After applying the patch:

```
Moodle 4.5.6+ (Build: 20250815), e07cf88f4d88c2ebe39606ad9fcf4f6b7affab3a
Php: 8.3.24, pgsql: 17.6 (Debian 17.6-1.pgdg13+1), OS: Linux 6.14.0-27-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.......                                                             7 / 7 (100%)

Time: 00:01.850, Memory: 76.50 MB

OK (7 tests, 16 assertions)
root@95fd2fd4bfb0:/var/www/moodle45#
```